### PR TITLE
Thread health checker

### DIFF
--- a/src/profiler_plugin/plugin.py
+++ b/src/profiler_plugin/plugin.py
@@ -94,10 +94,9 @@ class ProfilerPlugin(QObject):
         self._teardown_loggers()
         self._teardown_loggers = lambda: None
 
-        if self._event_recorder:
-            self._event_recorder.cleanup()
         if self._profiler_panel_layout:
             self._profiler_panel_layout.removeWidget(self._profiler_extension)
         if self._profiler_extension:
+            self._profiler_extension.cleanup()
             self._profiler_extension.deleteLater()
         self._profiler_extension = None  # type:ignore[assignment]

--- a/src/profiler_test_utils/decorator_utils.py
+++ b/src/profiler_test_utils/decorator_utils.py
@@ -15,9 +15,14 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with profiler-qgis-plugin. If not, see <https://www.gnu.org/licenses/>.
+import time
 
 from profiler_test_utils import utils
-from qgis_profiler.decorators import profile, profile_class
+from qgis_profiler.decorators import (
+    profile,
+    profile_class,
+)
+from qgis_profiler.meters.thread_health_checker import MainThreadHealthChecker
 
 EXTRA_GROUP = "New group"
 EXPECTED_TIME = 0.01
@@ -27,6 +32,10 @@ class DecoratorTester:
     @profile()
     def add(self, a: int, b: int) -> int:
         return _add(a, b)
+
+    @MainThreadHealthChecker.monitor()
+    def monitor_thread_health(self) -> None:
+        time.sleep(0.1)
 
     @profile(name="Add numbers")
     def add_with_name_kwarg(self, a: int, b: int) -> int:

--- a/src/qgis_profiler/meters/thread_health_checker.py
+++ b/src/qgis_profiler/meters/thread_health_checker.py
@@ -18,7 +18,8 @@
 
 import logging
 import time
-from typing import Optional
+import warnings
+from typing import Callable, Optional
 
 from qgis.core import QgsApplication
 from qgis.PyQt.QtCore import (
@@ -125,6 +126,30 @@ class MainThreadHealthChecker(Meter):
             )
             cls._instance.enabled = ProfilerSettings.thread_health_checker_enabled.get()
         return cls._instance
+
+    @classmethod
+    def monitor(  # noqa: PLR0913
+        cls,
+        name: Optional[str] = None,
+        group: Optional[str] = None,
+        name_args: Optional[list[str]] = None,
+        connect_to_profiler: bool = True,  # noqa: FBT001, FBT002
+        start_continuous_measuring: bool = True,  # noqa: FBT001, FBT002
+        measure_after_call: bool = False,  # noqa: FBT001, FBT002
+    ) -> Callable:
+        if measure_after_call:
+            warnings.warn(
+                "measure_after_call is not recommended for MainThreadHealthChecker",
+                stacklevel=1,
+            )
+        return super().monitor(
+            name,
+            group,
+            name_args,
+            connect_to_profiler,
+            start_continuous_measuring,
+            measure_after_call,
+        )
 
     def reset_parameters(self) -> None:
         self._poll_interval_ms = (

--- a/src/qgis_profiler/meters/thread_health_checker.py
+++ b/src/qgis_profiler/meters/thread_health_checker.py
@@ -1,0 +1,197 @@
+#  Copyright (c) 2025 profiler-qgis-plugin contributors.
+#
+#
+#  This file is part of profiler-qgis-plugin.
+#
+#  profiler-qgis-plugin is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  profiler-qgis-plugin is distributed in the hope that it will be
+#  useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+#  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with profiler-qgis-plugin. If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+import time
+from typing import Optional
+
+from qgis.core import QgsApplication
+from qgis.PyQt.QtCore import (
+    QElapsedTimer,
+    QEventLoop,
+    QObject,
+    QThread,
+    QTimer,
+    pyqtSignal,
+    pyqtSlot,
+)
+
+from qgis_profiler.meters.meter import Meter
+from qgis_profiler.settings import ProfilerSettings
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ThreadPoller(QObject):
+    poll = pyqtSignal()
+
+    def __init__(self, poll_interval_ms: int) -> None:
+        super().__init__()
+        self._polling_active: bool = False
+        self._elapsed_timer = QElapsedTimer()
+        self._poll_interval = poll_interval_ms
+        self._timer: Optional[QTimer] = None
+        self._event_loop = QEventLoop(self)
+
+    @pyqtSlot()
+    def start(self) -> None:
+        """Start polling."""
+        LOGGER.debug("Starting thread poller")
+        self._run_polling()
+        self._setup_timer()
+        self._event_loop.exec()
+
+    @pyqtSlot()
+    def stop(self) -> None:
+        """Stop polling."""
+        LOGGER.debug("Stopping thread poller")
+        if self._timer:
+            self._timer.stop()
+        self._event_loop.exit()
+
+    def elapsed_ms_after_last_ping(self) -> int:
+        """Return elapsed milliseconds since last ping."""
+        return self._elapsed_timer.elapsed()
+
+    def set_poll_finished(self) -> None:
+        """Mark polling as finished."""
+        self._polling_active = False
+
+    @pyqtSlot()
+    def _run_polling(self) -> None:
+        """Emit poll and restart the elapsed timer."""
+        if self._polling_active:
+            return
+        self._polling_active = True
+        self._elapsed_timer.restart()
+        self.poll.emit()
+
+    def _setup_timer(self) -> None:
+        """Set up the QTimer for periodic polling."""
+        self._timer = QTimer(self)
+        self._timer.timeout.connect(self._run_polling)
+        self._timer.start(self._poll_interval)
+
+
+class MainThreadHealthChecker(Meter):
+    """
+    Monitors the health of the main application thread.
+
+    Provides mechanisms to measure delays between thread pings and
+    detect anomalies based on a defined threshold.
+    """
+
+    _short_name = "main_thread"
+    _instance: Optional["MainThreadHealthChecker"] = None
+
+    def __init__(self, poll_interval_s: float, threshold_s: float) -> None:
+        super().__init__(supports_continuous_measurement=True)
+        self._poll_interval_ms = poll_interval_s * 1000
+        self._threshold_ms = threshold_s * 1000
+
+        self._poller: Optional[ThreadPoller] = None
+        self._polling_thread: Optional[QThread] = None
+        self._last_delay_ms: int = 0
+        LOGGER.debug("Health checker parameters initialized: %s", self)
+
+    def __str__(self) -> str:
+        return (
+            f"MainThreadHealthChecker("
+            f"poll_interval_s={self._poll_interval_ms / 1000}, "
+            f"threshold_s={self._threshold_ms / 1000})"
+        )
+
+    @classmethod
+    def get(cls) -> "MainThreadHealthChecker":
+        if cls._instance is None:
+            cls._instance = MainThreadHealthChecker(
+                poll_interval_s=ProfilerSettings.thread_health_checker_poll_interval.get(),
+                threshold_s=ProfilerSettings.thread_health_checker_threshold.get(),
+            )
+            cls._instance.enabled = ProfilerSettings.thread_health_checker_enabled.get()
+        return cls._instance
+
+    def reset_parameters(self) -> None:
+        self._poll_interval_ms = (
+            ProfilerSettings.thread_health_checker_poll_interval.get() * 1000
+        )
+        self._threshold_ms = (
+            ProfilerSettings.thread_health_checker_threshold.get() * 1000
+        )
+        self.enabled = ProfilerSettings.thread_health_checker_enabled.get()
+        LOGGER.debug("Health checker parameters reset: %s", self)
+
+    def _start_measuring(self) -> bool:
+        LOGGER.debug("Starting health checking")
+        self._poller = ThreadPoller(int(self._poll_interval_ms))
+        self._poller.poll.connect(self._on_poll_event)
+
+        self._polling_thread = QThread(self)
+        self._poller.moveToThread(self._polling_thread)
+
+        self._polling_thread.finished.connect(self._poller.stop)
+        self._polling_thread.finished.connect(self._poller.deleteLater)
+        self._polling_thread.finished.connect(self._polling_thread.deleteLater)
+        self._polling_thread.started.connect(self._poller.start)
+        self._polling_thread.start()
+        return True
+
+    def _stop_measuring(self) -> None:
+        LOGGER.debug("Stopping health checking")
+        if self._poller:
+            self._poller.poll.disconnect(self._on_poll_event)
+        if self._polling_thread and self._polling_thread.isRunning():
+            self._polling_thread.quit()
+            self._polling_thread.wait()
+        self._polling_thread = None
+        self._poller = None
+
+    def _measure(self) -> tuple[float, bool]:
+        """
+        Measure the delay between thread poll and main thread response.
+
+        :return: the last delay in milliseconds and whether
+        it exceeded the threshold.
+        """
+        if self._poller:
+            return self._last_delay_ms / 1000, self._last_delay_ms > self._threshold_ms
+
+        self._last_delay_ms = 0
+        self.start_measuring()
+        t = time.time()
+        while (
+            self._last_delay_ms == 0
+            and time.time() - t
+            < ProfilerSettings.thread_health_checker_poll_interval.get() * 2
+        ):
+            QgsApplication.processEvents()
+        self.cleanup()
+        return self._last_delay_ms / 1000, self._last_delay_ms > self._threshold_ms
+
+    @pyqtSlot()
+    def _on_poll_event(self) -> None:
+        """Handle poll events."""
+        if not self._poller:
+            # Should not be possible
+            return
+        elapsed_ms = self._poller.elapsed_ms_after_last_ping()
+        if elapsed_ms > self._threshold_ms:
+            LOGGER.debug("Took too long %s ms", elapsed_ms)
+            self._emit_anomaly(round(elapsed_ms / 1000, 3))
+        self._poller.set_poll_finished()
+        self._last_delay_ms = elapsed_ms

--- a/src/qgis_profiler/settings.py
+++ b/src/qgis_profiler/settings.py
@@ -41,6 +41,7 @@ class WidgetType(enum.Enum):
 class SettingCategory(enum.Enum):
     PROFILING = tr("Profiling")
     RECOVERY_METER = tr("Recovery time measuring meter")
+    THREAD_HEALTH_CHECKER_METER = tr("Main thread health checker meter")
 
 
 @dataclass
@@ -129,6 +130,27 @@ class ProfilerSettings(enum.Enum):
         default=100000,
         widget_config=WidgetConfig(minimum=1, maximum=1000000, step=10),
         category=SettingCategory.RECOVERY_METER,
+    )
+
+    # Health checker meter settings
+    thread_health_checker_enabled = Setting(
+        description=tr("Enable measure main thread health check meter"),
+        default=True,
+        category=SettingCategory.THREAD_HEALTH_CHECKER_METER,
+    )
+    thread_health_checker_poll_interval = Setting(
+        description=tr("A time in seconds between health check measurements"),
+        default=1.0,
+        category=SettingCategory.THREAD_HEALTH_CHECKER_METER,
+    )
+    thread_health_checker_threshold = Setting(
+        description=tr(
+            "A threshold in seconds of how fast main "
+            "thread should respond to health check"
+        ),
+        default=0.1,
+        category=SettingCategory.THREAD_HEALTH_CHECKER_METER,
+        widget_config=WidgetConfig(minimum=0.001, maximum=100.0, step=0.001),
     )
 
     @staticmethod

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -25,6 +25,7 @@ import pytest
 from profiler_test_utils.decorator_utils import ClassDecoratorTester, DecoratorTester
 from profiler_test_utils.utils import Dialog
 from qgis_profiler.meters.recovery_measurer import RecoveryMeasurer
+from qgis_profiler.meters.thread_health_checker import MainThreadHealthChecker
 from qgis_profiler.profiler import ProfilerWrapper
 from qgis_profiler.settings import ProfilerSettings
 
@@ -84,6 +85,13 @@ def mock_profiler(mocker: "MockerFixture") -> MagicMock:
 def mock_meter_recovery_measurer(mocker: "MockerFixture") -> MagicMock:
     mock_meter = mocker.MagicMock()
     mocker.patch.object(RecoveryMeasurer, "get", return_value=mock_meter)
+    return mock_meter
+
+
+@pytest.fixture
+def mock_thread_health_checker_meter(mocker: "MockerFixture") -> MagicMock:
+    mock_meter = mocker.MagicMock()
+    mocker.patch.object(MainThreadHealthChecker, "get", return_value=mock_meter)
     return mock_meter
 
 

--- a/test/meters/test_thread_health_checker.py
+++ b/test/meters/test_thread_health_checker.py
@@ -22,19 +22,27 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from qgis_profiler.meters.meter import MeterAnomaly
+from qgis_profiler.meters.meter import MeterAnomaly, MeterContext
 from qgis_profiler.meters.thread_health_checker import (
     MainThreadHealthChecker,
 )
 
 if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
     from pytestqt.qtbot import QtBot
+
+    from profiler_test_utils.decorator_utils import DecoratorTester
 
 
 @pytest.fixture
-def thread_health_checker() -> Iterator[MainThreadHealthChecker]:
+def thread_health_checker(
+    mock_profiler: "MagicMock",
+) -> Iterator[MainThreadHealthChecker]:
     """Fixture to create and return a MainThreadChecker instance."""
-    checker = MainThreadHealthChecker(0.010, 0.090)
+    checker = MainThreadHealthChecker.get()
+    checker._poll_interval_ms = 10
+    checker._threshold_ms = 90
     yield checker
     checker.cleanup()  # Ensure the checker is stopped after the test
     assert checker.is_measuring is False
@@ -58,6 +66,7 @@ def test_thread_poller_should_start_polling(
 
 def test_health_checker_should_emit_anomaly_on_thread_block(
     thread_health_checker: MainThreadHealthChecker,
+    meters_group: str,
     qtbot: "QtBot",
 ):
     # Arrange
@@ -72,5 +81,40 @@ def test_health_checker_should_emit_anomaly_on_thread_block(
     # Assert
     anomaly = signal_blocker.args[0]
     assert isinstance(anomaly, MeterAnomaly)
-    assert anomaly.name == "MainThreadHealthChecker"
+    assert anomaly.context == MeterContext(
+        "MainThreadHealthChecker (main_thread)", meters_group
+    )
     assert anomaly.duration_seconds == pytest.approx(0.2, rel=0.1)
+
+    # single-shot measure should give the latest delay
+    assert (
+        thread_health_checker.measure() == thread_health_checker._last_delay_ms / 1000
+    )
+
+
+def test_health_checker_measure_should_poll_blocking(
+    thread_health_checker: MainThreadHealthChecker,
+    qtbot: "QtBot",
+):
+    duration = thread_health_checker.measure()
+    assert duration == pytest.approx(0.1, abs=1e-1)
+
+
+def test_monitor_main_thread_health_decorator_should_profile(
+    thread_health_checker: MainThreadHealthChecker,
+    default_group: str,
+    decorator_tester: "DecoratorTester",
+    mock_profiler: "MagicMock",
+    qtbot: "QtBot",
+):
+    # Act
+    with qtbot.waitSignal(thread_health_checker.anomaly_detected, timeout=200):
+        decorator_tester.monitor_thread_health()
+
+    # Assert
+    mock_profiler.add_record.assert_called_once_with(
+        "monitor_thread_health (main_thread)",
+        default_group,
+        pytest.approx(0.1, abs=1e-1),
+    )
+    assert thread_health_checker.is_measuring

--- a/test/meters/test_thread_health_checker.py
+++ b/test/meters/test_thread_health_checker.py
@@ -1,0 +1,76 @@
+#  Copyright (c) 2025 profiler-qgis-plugin contributors.
+#
+#
+#  This file is part of profiler-qgis-plugin.
+#
+#  profiler-qgis-plugin is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  profiler-qgis-plugin is distributed in the hope that it will be
+#  useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+#  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with profiler-qgis-plugin. If not, see <https://www.gnu.org/licenses/>.
+
+import time
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+import pytest
+
+from qgis_profiler.meters.meter import MeterAnomaly
+from qgis_profiler.meters.thread_health_checker import (
+    MainThreadHealthChecker,
+)
+
+if TYPE_CHECKING:
+    from pytestqt.qtbot import QtBot
+
+
+@pytest.fixture
+def thread_health_checker() -> Iterator[MainThreadHealthChecker]:
+    """Fixture to create and return a MainThreadChecker instance."""
+    checker = MainThreadHealthChecker(0.010, 0.090)
+    yield checker
+    checker.cleanup()  # Ensure the checker is stopped after the test
+    assert checker.is_measuring is False
+
+
+def test_thread_poller_should_start_polling(
+    thread_health_checker: MainThreadHealthChecker, qtbot: "QtBot"
+):
+    assert not thread_health_checker.is_measuring
+
+    thread_health_checker.start_measuring()
+
+    assert thread_health_checker.is_measuring
+    assert thread_health_checker._poller
+    with qtbot.waitSignal(thread_health_checker._poller.poll, timeout=100):
+        """Poll should be called once"""
+
+    with qtbot.waitSignal(thread_health_checker._poller.poll, timeout=100):
+        """Wait again, timer should work"""
+
+
+def test_health_checker_should_emit_anomaly_on_thread_block(
+    thread_health_checker: MainThreadHealthChecker,
+    qtbot: "QtBot",
+):
+    # Arrange
+    thread_health_checker.start_measuring()
+
+    # Act
+    with qtbot.waitSignal(
+        thread_health_checker.anomaly_detected, timeout=200
+    ) as signal_blocker:
+        time.sleep(0.2)
+
+    # Assert
+    anomaly = signal_blocker.args[0]
+    assert isinstance(anomaly, MeterAnomaly)
+    assert anomaly.name == "MainThreadHealthChecker"
+    assert anomaly.duration_seconds == pytest.approx(0.2, rel=0.1)

--- a/test/plugin/test_profiler_extension.py
+++ b/test/plugin/test_profiler_extension.py
@@ -96,6 +96,7 @@ def profiler_extension(
     mock_event_recorder: "MagicMock",
     mock_settings_dialog: "MagicMock",
     mock_meter_recovery_measurer: "MagicMock",
+    mock_thread_health_checker_meter: "MagicMock",
     _modify_mock_profiler: None,
     stub_profiler_panel: StubProfilerPanel,
 ) -> ProfilerExtension:
@@ -117,7 +118,7 @@ def test_profiler_extension_initialization(
     assert profiler_extension.combo_box_group.itemText(0) == "Group 1"
     assert profiler_extension.button_record.isEnabled()
     assert not profiler_extension.button_record.isChecked()
-    assert len(profiler_extension._meters) == 1
+    assert len(profiler_extension._meters) == 2
     # Not enabled for existing groups
     assert not profiler_extension.button_clear.isEnabled()
     assert not profiler_extension.button_save.isEnabled()
@@ -133,6 +134,7 @@ def test_toggle_recording(
     profiler_extension: ProfilerExtension,
     mock_event_recorder: "MagicMock",
     mock_profiler: "MagicMock",
+    mock_thread_health_checker_meter: "MagicMock",
     stub_profiler_panel: StubProfilerPanel,
     qtbot: "QtBot",
     subtests: "SubTests",
@@ -144,6 +146,7 @@ def test_toggle_recording(
         # Assert
         mock_event_recorder.start_recording.assert_called_once()
         mock_profiler.create_group.assert_called_once_with(TEST_GROUP)
+        mock_thread_health_checker_meter.start_measuring.assert_called_once()
         assert profiler_extension.button_record.isChecked()
         assert stub_profiler_panel.combo_box_group.currentText() == TEST_GROUP
 
@@ -153,6 +156,7 @@ def test_toggle_recording(
 
         # Assert
         mock_event_recorder.stop_recording.assert_called_once()
+        mock_thread_health_checker_meter.stop_measuring.assert_called_once()
         assert not profiler_extension.button_record.isChecked()
 
     assert profiler_extension.button_clear.isEnabled()
@@ -178,6 +182,7 @@ def test_button_settings_should_open_settings_dialog(
     profiler_extension: ProfilerExtension,
     mock_settings_dialog: "MagicMock",
     mock_meter_recovery_measurer: "MagicMock",
+    mock_thread_health_checker_meter: "MagicMock",
     qtbot: "QtBot",
 ) -> None:
     # Arrange
@@ -190,16 +195,20 @@ def test_button_settings_should_open_settings_dialog(
     mock_settings_dialog.exec.assert_called_once()
     mock_meter_recovery_measurer.cleanup.assert_called_once()
     mock_meter_recovery_measurer.reset_parameters.assert_called_once()
+    mock_thread_health_checker_meter.cleanup.assert_called_once()
+    mock_thread_health_checker_meter.reset_parameters.assert_called()
 
 
 def test_cleanup_should_clean_meters(
     profiler_extension: ProfilerExtension,
     mock_settings_dialog: "MagicMock",
     mock_meter_recovery_measurer: "MagicMock",
+    mock_thread_health_checker_meter: "MagicMock",
 ) -> None:
     # Act
     profiler_extension.cleanup()
 
     # Assert
     mock_meter_recovery_measurer.cleanup.assert_called_once()
+    mock_thread_health_checker_meter.cleanup.assert_called_once()
     assert profiler_extension._meters == []

--- a/test/plugin/test_settings_dialog.py
+++ b/test/plugin/test_settings_dialog.py
@@ -32,6 +32,7 @@ from qgis.PyQt.QtWidgets import (
 
 from profiler_plugin.ui.settings_dialog import SettingsDialog
 from qgis_profiler.meters.recovery_measurer import RecoveryMeasurer
+from qgis_profiler.meters.thread_health_checker import MainThreadHealthChecker
 from qgis_profiler.settings import ProfilerSettings, SettingCategory
 
 if TYPE_CHECKING:
@@ -73,7 +74,7 @@ def test_settings_dialog_initialization(settings_dialog: "SettingsDialog") -> No
     assert set(settings_dialog._widgets.keys()) == set(ProfilerSettings)
     assert set(settings_dialog._groups.keys()) == set(SettingCategory)
     assert settings_dialog._button_calibrate_recovery_meter.isEnabled()
-    # utils.wait(4000)
+    # utils.wait(10000)
 
 
 @pytest.mark.parametrize(
@@ -179,3 +180,29 @@ def test_calibrate_recovery_threshold(
     assert mock_measure.call_count == 10
     assert settings_dialog._widgets[ProfilerSettings.recovery_threshold].value() == 9.45
     assert settings_dialog._button_calibrate_recovery_meter.isEnabled()
+
+
+def test_calibrate_health_checker_threshold(
+    settings_dialog: "SettingsDialog",
+    qtbot: "QtBot",
+    mocker: MockerFixture,
+) -> None:
+    # Arrange
+    mock_measure = mocker.patch.object(
+        MainThreadHealthChecker, "measure", side_effect=map(float, range(10))
+    )
+
+    # Act
+    qtbot.mouseClick(
+        settings_dialog._button_calibrate_thread_health_checker, Qt.LeftButton
+    )
+
+    # Assert
+    assert mock_measure.call_count == 10
+    assert (
+        settings_dialog._widgets[
+            ProfilerSettings.thread_health_checker_threshold
+        ].value()
+        == 9.45
+    )
+    assert settings_dialog._button_calibrate_thread_health_checker.isEnabled()

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -22,3 +22,4 @@ metaclass
 func
 varnames
 argcount
+poller

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -23,3 +23,4 @@ func
 varnames
 argcount
 poller
+stacklevel


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

This PR adds a new meter for health checking of main thread:
- Another thread is used to poll the main thread and if there are any delays, anomaly will be reported
- Calibration for the meter threshold

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other
- [ ] Non-breaking change
- [x] Breaking change
