### PR TITLE
feat: add `@profile_class` decorator for class method profiling

### DIFF
--- a/src/profiler_test_utils/decorator_utils.py
+++ b/src/profiler_test_utils/decorator_utils.py
@@ -17,7 +17,7 @@
 #  along with profiler-qgis-plugin. If not, see <https://www.gnu.org/licenses/>.
 
 from profiler_test_utils import utils
-from qgis_profiler.decorators import profile, profile_recovery_time
+from qgis_profiler.decorators import profile, profile_class, profile_recovery_time
 
 EXTRA_GROUP = "New group"
 EXPECTED_TIME = 0.01
@@ -53,6 +53,37 @@ class DecoratorTester:
     @staticmethod
     @profile()
     def static_add(a: int, b: int = 2) -> int:
+        return _add(a, b)
+
+
+@profile_class(
+    exclude=["add_excluded", "static_add_excluded", "classmethod_add_excluded"]
+)
+class ClassDecoratorTester:
+    def add(self, a: int, b: int) -> int:
+        return _add(a, b)
+
+    def add_complex(self, a: int, b: int) -> int:
+        utils.wait(int(EXPECTED_TIME * 1000))
+        return self.add(a, b) + self.add(a, b)
+
+    @staticmethod
+    def static_add(a: int, b: int) -> int:
+        return _add(a, b)
+
+    @classmethod
+    def classmethod_add(cls, a: int, b: int) -> int:
+        return _add(a, b)
+
+    def add_excluded(self, a: int, b: int) -> int:
+        return _add(a, b)
+
+    @staticmethod
+    def static_add_excluded(a: int, b: int) -> int:
+        return _add(a, b)
+
+    @classmethod
+    def classmethod_add_excluded(cls, a: int, b: int) -> int:
         return _add(a, b)
 
 

--- a/src/profiler_test_utils/decorator_utils.py
+++ b/src/profiler_test_utils/decorator_utils.py
@@ -41,6 +41,10 @@ class DecoratorTester:
     def add_with_name_kwarg(self, a: int, b: int) -> int:
         return _add(a, b)
 
+    @profile(event_args=["a"])
+    def add_with_event_args(self, a: int, b: int) -> int:
+        return _add(a, b)
+
     @profile(group=EXTRA_GROUP)
     def add_with_group_kwarg(self, a: int, b: int) -> int:
         return _add(a, b)

--- a/src/profiler_test_utils/decorator_utils.py
+++ b/src/profiler_test_utils/decorator_utils.py
@@ -71,6 +71,10 @@ class ClassDecoratorTester:
         utils.wait(int(EXPECTED_TIME * 1000))
         return self.add(a, b) + self.add(a, b)
 
+    @profile(event_args=["a", "b"])
+    def add_with_event_args(self, a: int, b: int) -> int:
+        return _add(a, b)
+
     @staticmethod
     def static_add(a: int, b: int) -> int:
         return _add(a, b)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from profiler_test_utils.decorator_utils import DecoratorTester
+from profiler_test_utils.decorator_utils import ClassDecoratorTester, DecoratorTester
 from profiler_test_utils.utils import Dialog
 from qgis_profiler.meters.recovery_measurer import RecoveryMeasurer
 from qgis_profiler.profiler import ProfilerWrapper
@@ -98,3 +98,8 @@ def dialog(qtbot: "QtBot", qgis_parent: "QWidget") -> Dialog:
 @pytest.fixture
 def decorator_tester() -> DecoratorTester:
     return DecoratorTester()
+
+
+@pytest.fixture
+def class_decorator_tester() -> ClassDecoratorTester:
+    return ClassDecoratorTester()

--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -237,6 +237,12 @@ def test_profile_decorator_should_profile_method(
             [ProfilerResult("add", "", EXPECTED_TIME)],
         ),
         (
+            "add_with_event_args",
+            3,
+            "add_with_event_args(a=1, b=2)",
+            [ProfilerResult("add_with_event_args(a=1, b=2)", "", EXPECTED_TIME)],
+        ),
+        (
             "static_add",
             3,
             "static_add",
@@ -292,6 +298,7 @@ def test_profile_decorator_should_profile_method(
     ],
     ids=[
         "auto profile method",
+        "auto profile method with event args",
         "auto profile static method",
         "auto profile class method",
         "auto profile complex method",

--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -196,12 +196,19 @@ def test_profiler_context_manager(
                 ),
             ],
         ),
+        (
+            "add_with_event_args",
+            3,
+            "add_with_event_args(a=1)",
+            [ProfilerResult("add_with_event_args(a=1)", "", EXPECTED_TIME)],
+        ),
     ],
     ids=[
         "profile method with name arg",
         "profile method without name arg",
         "profile static method",
         "profile complex method",
+        "profile method with event args",
     ],
 )
 @pytest.mark.usefixtures("log_profiler_data")

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -19,3 +19,4 @@ pytestqt
 qtbot
 subtests
 metaclass
+func

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -20,3 +20,5 @@ qtbot
 subtests
 metaclass
 func
+varnames
+argcount


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

This PR:
- Adds a new `profile_class` decorator to automate profiling whole class (or plugin).
  - Adds possibility to include and exclude wanted methods

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other
- [x] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [ ] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/segment-reshape-qgis-plugin/blob/main/CHANGELOG.md
